### PR TITLE
Fix ProjectCard.propTypes.children

### DIFF
--- a/src/components/ProjectCard.jsx
+++ b/src/components/ProjectCard.jsx
@@ -34,6 +34,6 @@ export default ProjectCard;
 ProjectCard.propTypes = {
   title: PropTypes.string.isRequired,
   link: PropTypes.string.isRequired,
-  children: PropTypes.object.isRequired,
+  children: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
   bg: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
Error:

![image](https://user-images.githubusercontent.com/1512341/45657965-f44e6400-bac2-11e8-9e47-fe83819e966c.png)

```log
Warning: Failed prop type: Invalid prop `children` of type `string` supplied to `ProjectCard`, expected `object`.
    in ProjectCard (at pages/index.jsx:172)
    in Index (created by PageRenderer)
    in PageRenderer (at json-store.js:93)
    in JSONStore (at root.js:59)
    in EnsureResources (created by RouteHandler)
    in ScrollContext (at root.js:80)
    in RouteHandler (created by Root)
    in div (created by FocusHandlerImpl)
    in FocusHandlerImpl (created by Context.Consumer)
    in FocusHandler (created by RouterImpl)
    in RouterImpl (created by LocationProvider)
    in LocationProvider (created by Context.Consumer)
    in Location (created by Context.Consumer)
    in Router (created by Root)
    in Root (at root.js:104)
    in _default (created by HotExported_default)
    in AppContainer (created by HotExported_default)
    in HotExported_default (at app.js:55)
```