### PR TITLE
Fix grammatical errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Based on [gatsby-tailwind-demo](https://github.com/jlengstorf/gatsby-tailwind-de
 
 ## Why?
 
-If you want to quickly bootstrap a design/photography portfolio or use it as a foundation for your personal site the *gatsby-starter-portfolio* are a perfect fit for you! The project's goal is to offer minimalistic and fast websites. 
+If you want to quickly bootstrap a design/photography portfolio or use it as a foundation for your personal site the *gatsby-starter-portfolio* is a perfect fit for you! The project's goal is to offer minimalistic and fast websites. 
 
 I hope you like my starters and create something awesome! To see some of my work you can visit my [website](https://www.lekoarts.de) or support me on [Patreon](https://www.patreon.com/lekoarts) to get some neat rewards (4K images, project files, tutorial insights). Every pledge on Patreon helps me creating more free starters!
 
@@ -103,7 +103,7 @@ module.exports = {
 };
 ```
 
-2) Use the `tailwind.js` file to configure TailwindCSS. Their [documentation](https://tailwindcss.com/docs/configuration) explains it step-by-setp.
+2) Use the `tailwind.js` file to configure TailwindCSS. Their [documentation](https://tailwindcss.com/docs/configuration) explains it step-by-step.
 
 3) Modify the files in the `src/styles` directory.
 
@@ -119,7 +119,7 @@ module.exports = {
 - If you want the SVG to be hidden on mobile view, add `className={hidden}` to the SVG component
 - You can define the width via the TailwindCSS width [option](https://tailwindcss.com/docs/width)
 - The colors get defined via the TailwindCSS color [option](https://tailwindcss.com/docs/colors)
-    - Please note that you will either have to define the color in `stroke` **or** `fill` depending on the icon. For referance have a look at the currently used SVGs
+    - Please note that you will either have to define the color in `stroke` **or** `fill` depending on the icon. For reference, have a look at the currently used SVGs
 - The options `left` and `top` position the icon relatively to its parent container
 - You can also wrap the SVGs with `<UpDown />` or `<UpDownWide />` to animate them
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Based on [gatsby-tailwind-demo](https://github.com/jlengstorf/gatsby-tailwind-de
 
 ## Why?
 
-If you want to quickly bootstrap a design/photography portfolio or use it as a foundation for your personal site the *gatsby-starter-portfolio* is a perfect fit for you! The project's goal is to offer minimalistic and fast websites. 
+If you want to quickly bootstrap a design/photography portfolio or use it as a foundation for your personal site, the starters in *gatsby-starter-portfolio* are a perfect fit for you! The project's goal is to offer minimalistic and fast websites. 
 
-I hope you like my starters and create something awesome! To see some of my work you can visit my [website](https://www.lekoarts.de) or support me on [Patreon](https://www.patreon.com/lekoarts) to get some neat rewards (4K images, project files, tutorial insights). Every pledge on Patreon helps me creating more free starters!
+I hope you like my starters and create something awesome! To see some of my work, you can visit my [website](https://www.lekoarts.de) or support me on [Patreon](https://www.patreon.com/lekoarts) to get some neat rewards (4K images, project files, tutorial insights). Every pledge on Patreon helps me create more free starters!
 
-Also check out the other *gatsby-starter-portfolio*:
+Also, check out the other themes for *gatsby-starter-portfolio*:
 - [gatsby-starter-portfolio-emma](https://github.com/LeKoArts/gatsby-starter-portfolio-emma)
 - [gatsby-starter-portfolio-emilia](https://github.com/LeKoArts/gatsby-starter-portfolio-emilia)
 - [gatsby-starter-portfolio-bella](https://github.com/LeKoArts/gatsby-starter-portfolio-bella)
@@ -63,7 +63,7 @@ npm run dev
 
 ### Adding new features/plugins
 
-You can add other features by having a look at the official [plugins page](https://www.gatsbyjs.org/docs/plugins/)
+You can add other features by having a look at the official [plugins page](https://www.gatsbyjs.org/docs/plugins/).
 
 ### Building your site
 
@@ -115,7 +115,7 @@ module.exports = {
   <SVG icon="box" width={6} fill={colors['grey-darker']} left="60%" top="15%" />
 ```
 
-- For `icon` you have the options: `triangle, circle, arrowUp, upDown, box, hexa`
+- For `icon`, you have the options: `triangle, circle, arrowUp, upDown, box, hexa`
 - If you want the SVG to be hidden on mobile view, add `className={hidden}` to the SVG component
 - You can define the width via the TailwindCSS width [option](https://tailwindcss.com/docs/width)
 - The colors get defined via the TailwindCSS color [option](https://tailwindcss.com/docs/colors)
@@ -125,7 +125,7 @@ module.exports = {
 
 ### Typography
 
-Instead of relying on Google's CDN to host its fonts this site self-hosts the fonts and therefore profits from increased performance. The installed fonts can be found in `src/pages/index.jsx`:
+Instead of relying on Google's CDN to host its fonts, this site self-hosts the fonts and therefore benefits from increased performance. The installed fonts can be found in `src/pages/index.jsx`:
 
 ```JSX
 import 'typeface-cantata-one';


### PR DESCRIPTION
Three changes in the documentation. The changes fix grammar and spelling errors.
"explains it step-by-setp" -> "explains it step-by-step." (Spelling error/typo)
"For referance" -> "For reference," (Spelling error/typo)
"the gatsby-starter-portfolio are a perfect fit" -> "the gatsby-starter-portfolio is a perfect fit" (Grammar error)