### PR TITLE
Implemented missing <noscript> tag

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -22,8 +22,8 @@ const HTML = ({ htmlAttributes, headComponents, bodyAttributes, preBodyComponent
         }}
       >
         Your browser has JavaScript disabled or does not support JavaScript. This website does not work properly without
-        it. Any recently updated browser should display this page properly. This site is guarenteed to work on e.g. the
-        latest Chrome or Firefox
+        it. Any recently updated browser should display this page properly. This site is guaranteed to work on e.g. the
+        latest Chrome or Firefox.
         <br />
         <br />
         Sorry for the inconvenience.

--- a/src/html.js
+++ b/src/html.js
@@ -19,6 +19,8 @@ const HTML = ({ htmlAttributes, headComponents, bodyAttributes, preBodyComponent
           display: 'flex',
           justifyContent: 'center',
           alignItems: 'center',
+          color: 'black',
+          backgroundColor: 'white',
         }}
       >
         Your browser has JavaScript disabled or does not support JavaScript. This website does not work properly without

--- a/src/html.js
+++ b/src/html.js
@@ -2,8 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 const HTML = ({ htmlAttributes, headComponents, bodyAttributes, preBodyComponents, body, postBodyComponents }) => (
-  <html lang="en"
-    {...htmlAttributes}>
+  <html lang="en" {...htmlAttributes}>
     <head>
       <meta charSet="utf-8" />
       <meta httpEquiv="x-ua-compatible" content="ie=edge" />
@@ -15,13 +14,16 @@ const HTML = ({ htmlAttributes, headComponents, bodyAttributes, preBodyComponent
       <div key="body" id="___gatsby" dangerouslySetInnerHTML={{ __html: body }} />
       {postBodyComponents}
 
-      <noscript style={{
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center'
-      }}>
+      <noscript
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
         Your browser has JavaScript disabled or does not support JavaScript. This website does not work properly without
-        it. Any recently updated browser should display this page properly. This site is guarenteed to work on e.g. the latest Chrome or Firefox
+        it. Any recently updated browser should display this page properly. This site is guarenteed to work on e.g. the
+        latest Chrome or Firefox
         <br />
         <br />
         Sorry for the inconvenience.

--- a/src/html.js
+++ b/src/html.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const HTML = ({ htmlAttributes, headComponents, bodyAttributes, preBodyComponents, body, postBodyComponents }) => (
+  <html lang="en"
+    {...htmlAttributes}>
+    <head>
+      <meta charSet="utf-8" />
+      <meta httpEquiv="x-ua-compatible" content="ie=edge" />
+      <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+      {headComponents}
+    </head>
+    <body {...bodyAttributes}>
+      {preBodyComponents}
+      <div key="body" id="___gatsby" dangerouslySetInnerHTML={{ __html: body }} />
+      {postBodyComponents}
+
+      <noscript style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center'
+      }}>
+        Your browser has JavaScript disabled or does not support JavaScript. This website does not work properly without
+        it. Any recently updated browser should display this page properly. This site is guarenteed to work on e.g. the latest Chrome or Firefox
+        <br />
+        <br />
+        Sorry for the inconvenience.
+      </noscript>
+    </body>
+  </html>
+)
+
+HTML.propTypes = {
+  htmlAttributes: PropTypes.object.isRequired,
+  headComponents: PropTypes.array.isRequired,
+  bodyAttributes: PropTypes.object.isRequired,
+  preBodyComponents: PropTypes.array.isRequired,
+  body: PropTypes.string.isRequired,
+  postBodyComponents: PropTypes.array.isRequired,
+}
+
+export default HTML


### PR DESCRIPTION
Hey, I noticed that for some reason the default <noscript> tag Gatsby ships is missing here. I followed the docs and added our own tag simply saying this if a user without JavaScript accesses the site:

> Your browser has JavaScript disabled or does not support JavaScript. This website does not work properly without it. Any recently updated browser should display this page properly. This site is guaranteed to work on e.g. latest Chrome or Firefox. Sorry for the inconvenience.
