### PR TITLE
feat: Use react-spring v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "react-helmet": "^5.2.0",
-    "react-spring": "^7.2.10",
+    "react-spring": "^8.0.1",
     "styled-components": "^4.1.3",
     "tailwind.macro": "^0.5.10",
     "tailwindcss": "^0.7.4",

--- a/src/elements/Content.jsx
+++ b/src/elements/Content.jsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 import tw from 'tailwind.macro'
-import { ParallaxLayer } from 'react-spring/addons.cjs'
+import { ParallaxLayer } from 'react-spring/renderprops-addons.cjs'
 
 const Content = styled(ParallaxLayer)`
   ${tw`p-6 md:p-12 lg:p-24 justify-center items-center flex z-50`};

--- a/src/elements/Dividers.jsx
+++ b/src/elements/Dividers.jsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 import tw from 'tailwind.macro'
-import { ParallaxLayer } from 'react-spring/addons.cjs'
+import { ParallaxLayer } from 'react-spring/renderprops-addons.cjs'
 
 export const Divider = styled(ParallaxLayer)`
   ${tw`absolute w-full h-full`};

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import tw from 'tailwind.macro'
-import { Parallax } from 'react-spring/addons.cjs'
+import { Parallax } from 'react-spring/renderprops-addons.cjs'
 
 // Components
 import Layout from '../components/Layout'

--- a/yarn.lock
+++ b/yarn.lock
@@ -9142,10 +9142,10 @@ react-side-effect@^1.1.0:
     exenv "^1.2.1"
     shallowequal "^1.0.1"
 
-react-spring@^7.2.10:
-  version "7.2.10"
-  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-7.2.10.tgz#eacbf429327bea058677c3a01af87b9c387f4aa6"
-  integrity sha512-bsbgQh1DzTqjwuD1tDZ7Nu04G5JhNNXdezkcJ5xXNboedN/MPe0K+X/MtypUxXBUCLYT0r5oKT3zj4STqVpnPA==
+react-spring@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-8.0.1.tgz#9896d6037bc99c24bed0fecf5ac8d0992724b7dd"
+  integrity sha512-IekJasCvYOOHk+YCtIZEqmk5C57YugzA+qWP6mXAZxEWYQ/jt3TzmTPXhtpzjPgbE+RzSVJxGEAFiVptw9vqxQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
 


### PR DESCRIPTION
There is no Hooks version for Parallax (yet) but updating the version requires other imports