### PR TITLE
 doc: add step for install babel-plugin-tailwind-components

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ To copy and install this starter run this command (with "project-name" being the
 
 ```
 gatsby new project-name https://github.com/LekoArts/gatsby-starter-portfolio-cara
+npm install --save-dev babel-plugin-macros tailwind.macro
 cd project-name
 npm run dev
 ```


### PR DESCRIPTION
This is related to issue #108.
Getting ` There was an error trying to load the config "tailwind" for the macro imported from "tailwind.macro. Please see the error thrown for more information` errors when running `npm run build` without install babel-plugin-tailwind-components.

Screenshot:
without `npm install --save-dev babel-plugin-macros tailwind.macro`
![image](https://user-images.githubusercontent.com/6004123/61970044-cc584880-af90-11e9-908f-29000b2e17a3.png)

after `npm install --save-dev babel-plugin-macros tailwind.macro`
![image](https://user-images.githubusercontent.com/6004123/61970495-beef8e00-af91-11e9-9ee8-47cb70593224.png)